### PR TITLE
feat: Limitar quantidade de blocos por fase no Blockly

### DIFF
--- a/src/components/game/GameArea.jsx
+++ b/src/components/game/GameArea.jsx
@@ -3,7 +3,7 @@ import { useGameState, GAME_STATES } from '../../contexts/GameStateContext';
 import { gameEventBus } from '../../utils/gameEvents';
 import ConfettiOverlay from './ConfettiOverlay';
 
-export default function GameArea({ children }) {
+export default function GameArea({ children, blocosRestantes = null }) {
   const { 
     estadoExecucao, 
     codigoGerado,
@@ -55,8 +55,19 @@ export default function GameArea({ children }) {
     <div 
       className="w-full h-full overflow-hidden relative flex items-center justify-center game-area-container" 
       style={{ backgroundColor: "#F1EEE7" }}
+      id="visualization"
     >
       <ConfettiOverlay isActive={showConfetti} />
+      
+      {/* Indicador de blocos restantes */}
+      {blocosRestantes !== null && (
+        <div id="capacityBubble">
+          <div id="capacity" style={{ display: 'block' }}>
+            Blocos restantes: <span className="capacityNumber">{blocosRestantes}</span>
+          </div>
+        </div>
+      )}
+      
       <div className="flex items-center justify-center w-full h-full phaser-container">
         {children}
       </div>

--- a/src/games/automato/AutomatoGame.jsx
+++ b/src/games/automato/AutomatoGame.jsx
@@ -48,10 +48,12 @@ export default function AutomatoGame() {
     <GameBase
       gameFactory={createGame}
       gameConfig={gameConfig}
-      editor={({ faseAtual }) => (
+      editor={(props) => (
         <GameEditor onExecutar={handleExecutar}>
           <BlocklyEditor
-            toolboxJson={generateDynamicToolbox(faseAtual.allowedBlocks)}
+            toolboxJson={generateDynamicToolbox(props.faseAtual.allowedBlocks)}
+            onWorkspaceChange={props.onWorkspaceChange}
+            maxBlocks={props.faseAtual.maxBlocks}
             ref={workspaceRef}
           />
         </GameEditor>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -197,3 +197,27 @@ svg[class*="blockly"] .blocklyScrollbarHorizontal {
   width: 100% !important;
   height: 100% !important;
 }
+
+#visualization {
+  position: relative;
+}
+
+#capacityBubble {
+  position: absolute;
+  margin-top: -0.5em;
+  left: 10px;
+  bottom: 10px;
+  z-index: 10;
+}
+
+#capacity {
+  display: none;
+  color: #fff;
+  padding: 5px 1em;
+  border-radius: 15px;
+  background-color: rgba(64,64,64,.7);
+  font-size: large;
+}
+.capacityNumber {
+  font-weight: bold;
+}


### PR DESCRIPTION
## Descrição:
Implementar uma funcionalidade que permita definir e restringir o número máximo de blocos que o usuário pode utilizar em cada fase do jogo. O objetivo é aumentar o desafio e incentivar soluções mais eficientes.

Checklist:

- [x]  Adicionar campo maxBlocks na configuração de cada fase.
- [x] Integrar o limite de blocos na inicialização do Blockly.
- [x] Exibir ao usuário o número de blocos restantes e/ou o limite atingido.
- [x] Impedir a adição de novos blocos ao atingir o limite.
- [x] Testar a funcionalidade em diferentes fases e dispositivos.

## Critérios de Aceite:

- [x] O usuário não consegue adicionar mais blocos do que o permitido na fase.
- [x] O limite pode ser configurado individualmente para cada fase.
- [x] O usuário recebe feedback visual ao atingir o limite.